### PR TITLE
Bugfix/Sanitized highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export class App {
 
 Some of these libraries have dependencies which are not provided by this library, so please install them by yourself in your project.
 ```bash
-npm install momentjs --save
+npm install moment --save
 ```
 
 If you want to use the sanitize-html-html-sanitizer [value-converter](src/value-converters/README.md):

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"optionalPeerDependencies": {
 		"apexcharts": "^3.35.0",
 		"aurelia-templating": "^1.11.1",
+		"aurelia-validation": "^2.0.0-rc2",
 		"jquery": "^3.5.1",
 		"moment": "^2.29.1",
 		"moment-duration-format": "^2.3.2",
@@ -28,7 +29,6 @@
 		"aurelia-event-aggregator": "^1.0.3",
 		"aurelia-loader-webpack": "^2.2.1",
 		"aurelia-polyfills": "^1.3.4",
-		"aurelia-validation": "^2.0.0-rc2",
 		"aurelia-webpack-plugin": "^4.0.0",
 		"jest": "^27.5.1",
 		"ts-jest": "^27.1.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"aurelia-event-aggregator": "^1.0.3",
 		"aurelia-loader-webpack": "^2.2.1",
 		"aurelia-polyfills": "^1.3.4",
+		"aurelia-validation": "^2.0.0-rc2",
 		"aurelia-webpack-plugin": "^4.0.0",
 		"jest": "^27.5.1",
 		"ts-jest": "^27.1.4",

--- a/src/value-converters/highlight-text-value-converter.ts
+++ b/src/value-converters/highlight-text-value-converter.ts
@@ -36,7 +36,7 @@ export class HighlightTextValueConverter {
             regExp = new RegExp(this._htmlSanitizer.sanitize(regExp.source), regExp.flags);
             const match = value.match(regExp);
             if (match && match.length) {
-                value = value.replace(regExp, '<mark>$1</mark>');
+                value = value.replace(regExp, '<mark>$&</mark>');
             }
         }
 

--- a/src/value-converters/highlight-text-value-converter.ts
+++ b/src/value-converters/highlight-text-value-converter.ts
@@ -1,5 +1,6 @@
 import {HTMLSanitizer} from "aurelia-templating-resources";
 import {autoinject} from "aurelia-dependency-injection";
+import escapeStringRegexp from "escape-string-regexp";
 
 /**
  * Highlights text by given text or precompiled regular expression.
@@ -26,7 +27,7 @@ export class HighlightTextValueConverter {
         if (text instanceof RegExp) {
             regExp = text;
         } else if (text && text.length > 0) {
-            regExp = new RegExp("(" + text + ")", "ig");
+            regExp = new RegExp("(" + escapeStringRegexp(text) + ")", "ig");
         }
 
         if (regExp) {

--- a/src/value-converters/highlight-text-value-converter.ts
+++ b/src/value-converters/highlight-text-value-converter.ts
@@ -30,6 +30,9 @@ export class HighlightTextValueConverter {
         }
 
         if (regExp) {
+            // value is sanitized, so the RegExp has to be sanitized as well to match the results
+            // this fixes the issue with &, <, >, "
+            regExp = new RegExp(this._htmlSanitizer.sanitize(regExp.source), regExp.flags);
             const match = value.match(regExp);
             if (match && match.length) {
                 value = value.replace(regExp, '<mark>$1</mark>');

--- a/tests/value-converters/highlight-text-value-converter.test.ts
+++ b/tests/value-converters/highlight-text-value-converter.test.ts
@@ -1,0 +1,46 @@
+import 'aurelia-polyfills'
+import {Container} from "aurelia-dependency-injection"
+import {HTMLSanitizer} from "aurelia-templating-resources";
+import {HighlightTextValueConverter} from "../../src/value-converters/highlight-text-value-converter"
+import {SanitizeHtmlHtmlSanitizer} from "../../src/value-converters/sanitize-html-html-sanitizer"
+import escapeStringRegexp from "escape-string-regexp";
+
+const container = new Container()
+container.makeGlobal()
+
+container.registerSingleton(HTMLSanitizer, SanitizeHtmlHtmlSanitizer)
+const htmlSanitizer = container.get(HTMLSanitizer) as SanitizeHtmlHtmlSanitizer
+const highlightTextValueConverter = container.get(HighlightTextValueConverter)
+
+let highlightingData: { inputString: string; inputRegExp: RegExp; outputString: string }[] = [
+    {inputString: null, inputRegExp: null, outputString: null}
+];
+
+for (let i = 0; i < 256; i++) {
+    let testString = String.fromCharCode(i)
+    highlightingData[i] = {
+        inputString: testString,
+        inputRegExp: new RegExp("(" + escapeStringRegexp(testString) + ")", "g"),
+        outputString: `<mark>${htmlSanitizer.sanitize(testString)}</mark>`
+    }
+}
+
+describe.each(highlightingData)(`toView with string`, (data) => {
+    it(`string '${data.inputString}' is surrounded by mark tags`, () => {
+        console.log(data.inputString)
+        const highlightedText = highlightTextValueConverter.toView(data.inputString, data.inputString)
+        console.log(highlightedText)
+        console.log(highlightedText === data.outputString)
+        expect(highlightedText).toMatch(data.outputString)
+    });
+});
+
+describe.each(highlightingData)(`toView with precompiled RegExp`, (data) => {
+    it(`regExp '${data.inputString}' result is surrounded by mark tags`, () => {
+        console.log(data.inputString)
+        const highlightedText = highlightTextValueConverter.toView(data.inputString, data.inputRegExp)
+        console.log(highlightedText)
+        console.log(highlightedText === data.outputString)
+        expect(highlightedText).toMatch(data.outputString)
+    });
+});


### PR DESCRIPTION
When a symbol that is sanitized by the HtmlSanitizer (&, <, >, ") is supposed to be highlighted, the RegExp can't find it anymore, as it is converted to "`&amp;`", "`&lt;`", "`&gt;`", "`&quot;`". 
This leads to bad results like `<mark>&</mark>amp;` or text not being highlighted at all.
This PR attempts to fix this by also sanitizing the used RegExp, which shouldn't create issues. Deeper testing can be done if necessary.
Two miscellaneous fixes for problems I ran into while setting up a dev environment are included.