### PR TITLE
(WIP) CacheService may try to write value for deleted key

### DIFF
--- a/src/services/cache-service.ts
+++ b/src/services/cache-service.ts
@@ -3,29 +3,27 @@
  * @author Mike Reiche <mike.reiche@t-systems.com>
  */
 export class CacheService {
-    private _cacheContainer = {};
+    private _cacheContainer = new Map<string, Entry<any>>();
     private _defaultCacheTtlSeconds = 10;
 
+    /** If a live entry exists, returns the (possibly still pending) result of said entry.
+     *  Otherwise, invokes {@link loadingFunction} and creates a new entry for it.
+     *  The returned Promise is already primed by call to {@link Promise#then}.
+     *  <p>The TTL of an entry only begins when the Promise resolves.</p>
+     */
     getForKeyWithLoadingFunction <T> (
         key:string,
         loadingFunction:() => Promise<T>,
         cacheTtlSeconds = this._defaultCacheTtlSeconds
     ):Promise<T> {
-        let cacheEntry = this._cacheContainer[key];
-        const now = (Date.now()/1000);
-        if (cacheEntry !== undefined) {
-            if (cacheEntry[0] >= now - cacheTtlSeconds) {
-                return cacheEntry[1];
-            }
+        const entry: Entry<T> | undefined = this._cacheContainer.get(key);
+        let result = entry?.read(cacheTtlSeconds)
+        if (!result) {
+            const request = loadingFunction()
+            this._cacheContainer.set(key, new Entry<T>(request))
+            result = request
         }
-
-        this._cacheContainer[key] = [
-            now,
-            loadingFunction().then(object=>{
-                return this._cacheContainer[key][1] = Promise.resolve(object);
-            })
-        ];
-        return this._cacheContainer[key][1];
+        return result
     }
 
     setDefaultCacheTtl(seconds:number) {
@@ -34,31 +32,92 @@ export class CacheService {
     }
 
     invalidate(keys:string[]) {
-        for (let key of keys) {
-            delete this._cacheContainer[key];
+        for (const key of keys) {
+            const entry = this._cacheContainer.get(key)
+            entry?.destructor()
+            this._cacheContainer.delete(key)
         }
         return this;
     }
 
+    /** @deprecated {@link Entry#read} dies on its own. */
     get outdatedKeys() {
-        const now = (Date.now()/1000);
-        let cacheEntry;
-        const keys = [];
-        for (let key in this._cacheContainer) {
-            cacheEntry = this._cacheContainer[key];
-            if (cacheEntry[0] < now - this._defaultCacheTtlSeconds) {
-                keys.push(key);
+        const now = nowInSeconds()
+        const keys: string[] = [];
+        for (const entry of this._cacheContainer.entries()) {
+            if (entry[1].isAlive(this._defaultCacheTtlSeconds, now)) {
+                keys.push(entry[0]);
             }
         }
         return keys;
     }
 
     get cacheKeys() {
-        return Object.keys(this._cacheContainer);
+        return this._cacheContainer.keys()
     }
 
     invalidateAll() {
-        this._cacheContainer = {};
+        this._cacheContainer.forEach(entry => entry.destructor())
+        this._cacheContainer = new Map<string, Entry<any>>()
         return this;
+    }
+}
+
+function nowInSeconds(): number {
+    return Date.now() / 1000
+}
+
+enum EntryState {
+    DEAD = 0, // falsy
+    WAITING,
+    WRITTEN,
+}
+
+export class Entry<T> {
+    private state: EntryState = EntryState.WAITING
+    /** Will only be set once the source has been resolved. */
+    private startOfLife: number | null = null
+    private value: Promise<T> | T
+
+    constructor(source: Promise<T>) {
+        this.value = source.then(result => this.write(result))
+    }
+
+    // FIXME ES2021: https://stackoverflow.com/a/71820676/3434465
+    destructor(): void {
+        this.write = result => result // will NOP when source finally resolves
+        this.state = EntryState.DEAD
+    }
+
+    // TODO: make private or inline when removing CacheService.outdatedKeys
+    /** An entry is alive until it has been resolved and its TTL has since passed. */
+    isAlive(lifespan: number, now = nowInSeconds()): boolean {
+        switch (this.state) {
+            case EntryState.WRITTEN:
+                return this.startOfLife + lifespan >= now
+            default:
+                return !!this.state
+        }
+    }
+
+    /** @return <code>false</code> if TTL has been passed */
+    read(lifespan: number): Promise<T> | false {
+        if (this.isAlive(lifespan)) {
+            return Promise.resolve(this.value)
+        }
+        else {
+            this.destructor()
+            return false
+        }
+    }
+
+    /** Replaces the source Promise with its resolved value (so we can keep returning resolving Promises) and starts TTL.
+     *  Will be replaced by {@link #destructor} with a NOP, such that the source Promise resolving after the Entry was invalidated does not cause an invalid state.
+     */
+    private write(result: T): T {
+        this.value = result // to be wrapped in fresh Promises, so we can read it more than once
+        this.state = EntryState.WRITTEN
+        this.startOfLife = nowInSeconds()
+        return result
     }
 }

--- a/tests/services/cache-service.test.ts
+++ b/tests/services/cache-service.test.ts
@@ -1,0 +1,57 @@
+import {CacheService, Entry} from "../../src/services/cache-service";
+
+describe("Entry", () => {
+    test(".destructor turns .write into NOP", () => {
+        let writeHappens: (string) => void
+        const writePromise = new Promise<string>(resolve => writeHappens = resolve)
+
+        const entry = new Entry(writePromise)
+        entry.destructor()
+        writeHappens("You shan't see this!")
+
+        expect(entry.read(10)).toStrictEqual(false)
+    })
+
+    test(".read returns Promise before writePromise resolves", () => {
+        const writePromise = new Promise<string>(_ => {}) // never resolves nor rejects
+        const entry = new Entry(writePromise)
+        expect(entry.read(-1)).toBeTruthy() // (even negative) lifespan ignored, because the write has not yet happened
+    })
+
+    test(".read returns resolving Promise once writePromise resolves", () => {
+        let writeHappens: (string) => void
+        const writtenWord = "Witness me!"
+        const writePromise = new Promise<string>(resolve => writeHappens = resolve)
+
+        const entry = new Entry(writePromise)
+        writeHappens(writtenWord)
+
+        expect(entry.read(1)).resolves.toBe(writtenWord)
+    })
+})
+
+describe("CacheService", () => {
+    test(".getForKeyWithLoadingFunction loading non-existing key creates new Entry", () => {
+        const cacheService = new CacheService() // empty
+        const key = "someKey"
+        const promise = Promise.resolve({})
+
+        expect(cacheService.cacheKeys).not.toContain(key) // Sanity Check
+        const result = cacheService.getForKeyWithLoadingFunction(key, () => promise)
+
+        expect(result).toStrictEqual(promise)
+        expect(cacheService.cacheKeys).toContain(key)
+    })
+
+    test(".getForKeyWithLoadingFunction loading existing key for dead Entry creates new Entry", () => {
+        const cacheService = new CacheService() // empty
+        const key = "someKey"
+        const promiseA = Promise.resolve({})
+        const promiseB = Promise.resolve("Eyo!")
+
+        const resultA = cacheService.getForKeyWithLoadingFunction(key, () => promiseA, 0) // immediately dies
+        const resultB = cacheService.getForKeyWithLoadingFunction(key, () => promiseB)
+
+        expect(resultA).not.toBe(resultB)
+    })
+})


### PR DESCRIPTION
? manually invalidated entries no longer crash when their Promise resolves
? no external deletion of keys necessary anymore
? TTL now only starts once value has arrived

resolves #41 