### PR TITLE
Configure RenovateBot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,30 @@
 {
   "extends": [
     "config:base"
+  ],
+  "assignees": ["Zsar"],
+  "automergeStrategy": "merge-commit",
+  "automergeSchedule": ["on saturday"],
+  "configMigration": true,
+  "rangeStrategy": "update-lockfile",
+  "reviewers": ["Zsar"],
+  "rollbackPrs": true,
+  "schedule": ["on sunday"],
+  "stabilityDays": 5,
+  "packageRules": [
+    {
+      "groupName": "trivial",
+      "matchUpdateTypes": ["bump", "digest", "lockFileMaintenance", "patch", "pin", "pinDigest", "rollback"],
+      "automerge": true
+    },
+    {
+      "groupName": "minor",
+      "matchUpdateTypes": ["minor"]
+    },
+    {
+      "groupName": "major",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
   ]
 }


### PR DESCRIPTION
? will automerge less-than-minor changes
? will create rollback PRs if updated versions have been pulled afterwards (Note: should not actually happen, because stabilityDays is bigger than time limit for pulling from npm registry)
? will group updates together instead of creating one PR for each dependency
? will only check updates on sundays
? will only create PRs for major versions if authorised to on dependency dashboard
? will update only lockfile, if in-range updates are available
? will wait for six days before considering a change stable