### PR TITLE
Configure RenovateBot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "assignees": ["Zsar"],
   "automergeStrategy": "merge-commit",
   "automergeSchedule": ["on saturday"],
+  "bumpVersion": "prerelease",
   "configMigration": true,
   "rangeStrategy": "update-lockfile",
   "reviewers": ["Zsar"],
@@ -19,7 +20,8 @@
     },
     {
       "groupName": "minor",
-      "matchUpdateTypes": ["minor"]
+      "matchUpdateTypes": ["minor"],
+      "automerge": true
     },
     {
       "groupName": "major",


### PR DESCRIPTION
Should now bump the version in package.json as well whenever it changes package-lock.json. Unsure whether I picked the correct setting - documentation is silent about order. It is either this or "major" for "everything".

Also went ahead and enabled automerge for minor version increases:
- Worked out so far.
- Should not merge if fails to build.

So I am willing to risk this and see how it goes.