### PR TITLE
Change PopoverCustomAttributes HTML attribute name

### DIFF
--- a/src/attributes/bootstrap/README.md
+++ b/src/attributes/bootstrap/README.md
@@ -62,4 +62,5 @@ npm install bootstrap@5.1.3
    data-popover
 >Tooltip</a>
 ```
-Note that for a "dismissable" popover using the attribute `data-trigger="focus"`, the element having the popover attached must be able to receive focus. (See this [StackOverflow answer](https://stackoverflow.com/a/1600194) on which elements can receive focus)
+Note that for a "dismissable" popover using the attribute `data-trigger="focus"`, the element having the popover attached must be able to receive focus. (See this [StackOverflow answer](https://stackoverflow.com/a/1600194) on which elements can receive focus).\
+The attribute name 'popover' may also be used, but is deprecated and will be removed when the official popover-API is supported by browsers. See [Chrome implementation status](https://chromestatus.com/feature/5463833265045504).

--- a/src/attributes/bootstrap/README.md
+++ b/src/attributes/bootstrap/README.md
@@ -59,7 +59,7 @@ npm install bootstrap@5.1.3
    title="Popover title"
    data-content="This is the content of the popover"
    data-placement="top"
-   popover
+   data-popover
 >Tooltip</a>
 ```
 Note that for a "dismissable" popover using the attribute `data-trigger="focus"`, the element having the popover attached must be able to receive focus. (See this [StackOverflow answer](https://stackoverflow.com/a/1600194) on which elements can receive focus)

--- a/src/attributes/bootstrap/popover-custom-attribute.ts
+++ b/src/attributes/bootstrap/popover-custom-attribute.ts
@@ -5,9 +5,10 @@ import {bindingMode} from "aurelia-binding";
 
 /**
  * @author Christoph Reinsch <christoph.reinsch@t-systems.com>
+ * @example See {@link import('./README.md') README.md/popover-custom-attribute}.
  */
 @autoinject()
-@customAttribute('data-popover', bindingMode.toView, ['popover'])
+@customAttribute('data-popover', bindingMode.twoWay, ['popover'])
 export class PopoverCustomAttribute {
     private popover: Popover | undefined
 

--- a/src/attributes/bootstrap/popover-custom-attribute.ts
+++ b/src/attributes/bootstrap/popover-custom-attribute.ts
@@ -1,10 +1,13 @@
 import {Popover} from "bootstrap"
 import {autoinject} from "aurelia-dependency-injection";
+import {customAttribute} from "aurelia-templating";
+import {bindingMode} from "aurelia-binding";
 
 /**
  * @author Christoph Reinsch <christoph.reinsch@t-systems.com>
  */
 @autoinject()
+@customAttribute('data-popover', bindingMode.toView, ['popover'])
 export class PopoverCustomAttribute {
     private popover: Popover | undefined
 


### PR DESCRIPTION
Added a `@customAttribute(name: string, defaultBindingMode?: number, aliases?: string[])` decorator.
Please share thoughts on the way of deprecating the old usage of the attribute.

Closes #74.