### PR TITLE
Fix imports in echarts components

### DIFF
--- a/src/components/echart/echart.ts
+++ b/src/components/echart/echart.ts
@@ -1,6 +1,6 @@
 import {bindable} from "aurelia-templating";
 import {bindingMode} from "aurelia-binding";
-import * as echarts from "echarts/core";
+import * as echarts from "echarts";
 import {ECBasicOption} from "echarts/types/dist/shared";
 
 /**


### PR DESCRIPTION
The echarts import was wrong and could not used with latest Echarts version.